### PR TITLE
add UnownedUnsafeTests to all Tests

### DIFF
--- a/Tests/WeakTests/XCTestManifests.swift
+++ b/Tests/WeakTests/XCTestManifests.swift
@@ -4,7 +4,8 @@ import XCTest
 public func allTests() -> [XCTestCaseEntry] {
     return [
         testCase(WeakTests.allTests),
-		testCase(UnownedTests.allTests)
+		testCase(UnownedTests.allTests),
+		testCase(UnownedUnsafeTests.allTests)
     ]
 }
 #endif


### PR DESCRIPTION
This pull request fix UnUnownedUnsafeTests is not in `allTests()`